### PR TITLE
feat: Add search.Resources tool

### DIFF
--- a/pkg/kubernetes/search.go
+++ b/pkg/kubernetes/search.go
@@ -1,0 +1,144 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// SearchResources searches for a query string in all resources across all namespaces.
+func (k *Kubernetes) SearchResources(ctx context.Context, query string, asTable bool) (runtime.Unstructured, error) {
+	// Discovery client is used to discover different supported API groups, versions and resources.
+	serverResources, err := k.manager.discoveryClient.ServerPreferredResources()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server resources: %w", err)
+	}
+
+	var matchingResources []unstructured.Unstructured
+	for _, apiResourceList := range serverResources {
+		for _, apiResource := range apiResourceList.APIResources {
+			// Skip resources that do not support the "list" verb
+			if !contains(apiResource.Verbs, "list") {
+				continue
+			}
+
+			gvk := schema.GroupVersionKind{
+				Group:   apiResourceList.GroupVersion,
+				Version: apiResource.Version,
+				Kind:    apiResource.Kind,
+			}
+			if gvk.Group == "" {
+				gvk.Group = "core"
+			}
+
+			if _, err := k.resourceFor(&gvk); err != nil {
+				// Ignore errors for resources that cannot be mapped
+				continue
+			}
+			var namespaces []string
+			if apiResource.Namespaced {
+				// Get all namespaces
+				nsListObj, err := k.NamespacesList(ctx, ResourceListOptions{})
+				if err != nil {
+					return nil, fmt.Errorf("failed to list namespaces: %w", err)
+				}
+				if unstructuredList, ok := nsListObj.(*unstructured.UnstructuredList); ok {
+					for _, ns := range unstructuredList.Items {
+						namespaces = append(namespaces, ns.GetName())
+					}
+				}
+			} else {
+				// For cluster-scoped resources, use an empty namespace
+				namespaces = append(namespaces, "")
+			}
+
+			for _, ns := range namespaces {
+				list, err := k.ResourcesList(ctx, &gvk, ns, ResourceListOptions{})
+				if err != nil {
+					// Ignore errors for resources that cannot be listed
+					continue
+				}
+
+				if unstructuredList, ok := list.(*unstructured.UnstructuredList); ok {
+					for _, item := range unstructuredList.Items {
+						match, err := matchResource(item, query)
+						if err != nil {
+							// Ignore errors during matching
+							continue
+						}
+						if match {
+							matchingResources = append(matchingResources, item)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if asTable {
+		return k.createTable(matchingResources)
+	}
+
+	return &unstructured.UnstructuredList{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "List",
+		},
+		Items: matchingResources,
+	}, nil
+}
+
+func (k *Kubernetes) createTable(resources []unstructured.Unstructured) (runtime.Unstructured, error) {
+	table := &metav1.Table{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "meta.k8s.io/v1",
+			Kind:       "Table",
+		},
+		ColumnDefinitions: []metav1.TableColumnDefinition{
+			{Name: "Namespace", Type: "string"},
+			{Name: "Kind", Type: "string"},
+			{Name: "Name", Type: "string"},
+		},
+	}
+
+	for _, res := range resources {
+		row := metav1.TableRow{
+			Cells: []interface{}{
+				res.GetNamespace(),
+				res.GetKind(),
+				res.GetName(),
+			},
+			Object: runtime.RawExtension{Object: &res},
+		}
+		table.Rows = append(table.Rows, row)
+	}
+
+	unstructuredObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(table)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert table to unstructured: %w", err)
+	}
+	return &unstructured.Unstructured{Object: unstructuredObject}, nil
+}
+
+func matchResource(resource unstructured.Unstructured, query string) (bool, error) {
+	data, err := json.Marshal(resource.Object)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal resource: %w", err)
+	}
+	return strings.Contains(strings.ToLower(string(data)), strings.ToLower(query)), nil
+}
+
+func contains(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/mcp/testdata/toolsets-core-tools.json
+++ b/pkg/mcp/testdata/toolsets-core-tools.json
@@ -418,5 +418,28 @@
       ]
     },
     "name": "resources_list"
+  },
+  {
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Search for a string in all resources.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "description": "The string to search for in the resources.",
+          "type": "string"
+        },
+        "as_table": {
+          "description": "Return the results as a table.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "query"
+      ]
+    },
+    "name": "search.Resources"
   }
 ]

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -538,5 +538,28 @@
       ]
     },
     "name": "resources_list"
+  },
+  {
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Search for a string in all resources.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "description": "The string to search for in the resources.",
+          "type": "string"
+        },
+        "as_table": {
+          "description": "Return the results as a table.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "query"
+      ]
+    },
+    "name": "search.Resources"
   }
 ]

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -524,5 +524,28 @@
       ]
     },
     "name": "resources_list"
+  },
+  {
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Search for a string in all resources.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "description": "The string to search for in the resources.",
+          "type": "string"
+        },
+        "as_table": {
+          "description": "Return the results as a table.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "query"
+      ]
+    },
+    "name": "search.Resources"
   }
 ]

--- a/pkg/toolsets/core/search.go
+++ b/pkg/toolsets/core/search.go
@@ -1,0 +1,59 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"k8s.io/utils/ptr"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+)
+
+func initSearch(_ kubernetes.Openshift) []api.ServerTool {
+	return []api.ServerTool{
+		{
+			Tool: api.Tool{
+				Name:        "search.Resources",
+				Description: "Search for a string in all resources.",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"query": {
+							Type:        "string",
+							Description: "The string to search for in the resources.",
+						},
+						"as_table": {
+							Type:        "boolean",
+							Description: "Return the results as a table.",
+						},
+					},
+					Required: []string{"query"},
+				},
+				Annotations: api.ToolAnnotations{
+					ReadOnlyHint: ptr.To(true),
+				},
+			},
+			Handler: searchResources,
+		},
+	}
+}
+
+func searchResources(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	query, ok := params.GetArguments()["query"].(string)
+	if !ok {
+		return api.NewToolCallResult("", fmt.Errorf("query is not a string")), nil
+	}
+
+	asTable := false
+	if val, ok := params.GetArguments()["as_table"].(bool); ok {
+		asTable = val
+	}
+
+	result, err := params.SearchResources(params, query, asTable)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to search resources: %v", err)), nil
+	}
+
+	return api.NewToolCallResult(params.ListOutput.PrintObj(result)), nil
+}

--- a/pkg/toolsets/core/toolset.go
+++ b/pkg/toolsets/core/toolset.go
@@ -26,6 +26,7 @@ func (t *Toolset) GetTools(o internalk8s.Openshift) []api.ServerTool {
 		initNamespaces(o),
 		initPods(),
 		initResources(o),
+		initSearch(o),
 	)
 }
 


### PR DESCRIPTION
This commit introduces a new `search.Resources` tool to the core toolset. This tool allows users to search for a string within all accessible Kubernetes resources.

The search is performed across all namespaces for namespaced resources and at the cluster level for cluster-scoped resources. The tool iterates through all discoverable API resources, lists their instances, and performs a case-insensitive search on the JSON representation of each resource.

The results can be returned as a list of unstructured resources or as a formatted table, providing a flexible way to view the search results.