### PR TITLE
feat: Add filtering to search.Resources tool

### DIFF
--- a/pkg/mcp/testdata/toolsets-core-tools.json
+++ b/pkg/mcp/testdata/toolsets-core-tools.json
@@ -434,6 +434,18 @@
         "as_table": {
           "description": "Return the results as a table.",
           "type": "boolean"
+        },
+        "api_version": {
+          "description": "Optional API version of the resource to search in.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Optional kind of the resource to search in.",
+          "type": "string"
+        },
+        "namespace_label_selector": {
+          "description": "Optional label selector to filter namespaces.",
+          "type": "string"
         }
       },
       "required": [

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -554,6 +554,18 @@
         "as_table": {
           "description": "Return the results as a table.",
           "type": "boolean"
+        },
+        "api_version": {
+          "description": "Optional API version of the resource to search in.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Optional kind of the resource to search in.",
+          "type": "string"
+        },
+        "namespace_label_selector": {
+          "description": "Optional label selector to filter namespaces.",
+          "type": "string"
         }
       },
       "required": [

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -540,6 +540,18 @@
         "as_table": {
           "description": "Return the results as a table.",
           "type": "boolean"
+        },
+        "api_version": {
+          "description": "Optional API version of the resource to search in.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Optional kind of the resource to search in.",
+          "type": "string"
+        },
+        "namespace_label_selector": {
+          "description": "Optional label selector to filter namespaces.",
+          "type": "string"
         }
       },
       "required": [

--- a/pkg/toolsets/core/search.go
+++ b/pkg/toolsets/core/search.go
@@ -27,6 +27,18 @@ func initSearch(_ kubernetes.Openshift) []api.ServerTool {
 							Type:        "boolean",
 							Description: "Return the results as a table.",
 						},
+						"api_version": {
+							Type:        "string",
+							Description: "Optional API version of the resource to search in.",
+						},
+						"kind": {
+							Type:        "string",
+							Description: "Optional kind of the resource to search in.",
+						},
+						"namespace_label_selector": {
+							Type:        "string",
+							Description: "Optional label selector to filter namespaces.",
+						},
 					},
 					Required: []string{"query"},
 				},
@@ -50,7 +62,22 @@ func searchResources(params api.ToolHandlerParams) (*api.ToolCallResult, error) 
 		asTable = val
 	}
 
-	result, err := params.SearchResources(params, query, asTable)
+	apiVersion := ""
+	if val, ok := params.GetArguments()["api_version"].(string); ok {
+		apiVersion = val
+	}
+
+	kind := ""
+	if val, ok := params.GetArguments()["kind"].(string); ok {
+		kind = val
+	}
+
+	namespaceLabelSelector := ""
+	if val, ok := params.GetArguments()["namespace_label_selector"].(string); ok {
+		namespaceLabelSelector = val
+	}
+
+	result, err := params.SearchResources(params, query, apiVersion, kind, namespaceLabelSelector, asTable)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to search resources: %v", err)), nil
 	}


### PR DESCRIPTION
This commit enhances the `search.Resources` tool by adding filtering capabilities. Users can now narrow down their search by specifying:

- A specific resource type (`apiVersion` and `kind`).
- A `namespace_label_selector` to search only within namespaces that match the given labels.

The implementation has been refactored to be more efficient. If a resource type is provided, the tool will now bypass the broad discovery of all server resources and directly query the specified type. This improves performance for targeted searches and resolves a test interference issue.

The tool's input schema and handler have been updated to support these new optional parameters, and the test fixtures have been updated accordingly.