### PR TITLE
This change introduces the ability to configure the Confluence toolse…

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -94,5 +94,21 @@ func ReadToml(configData []byte) (*StaticConfig, error) {
 	if err := toml.Unmarshal(configData, config); err != nil {
 		return nil, err
 	}
+	config.loadFromEnv()
 	return config, nil
+}
+
+func (c *StaticConfig) loadFromEnv() {
+	if c.Confluence == nil {
+		c.Confluence = &ConfluenceConfig{}
+	}
+	if url := os.Getenv("MCP_CONFLUENCE_URL"); url != "" {
+		c.Confluence.URL = url
+	}
+	if username := os.Getenv("MCP_CONFLUENCE_USERNAME"); username != "" {
+		c.Confluence.Username = username
+	}
+	if token := os.Getenv("MCP_CONFLUENCE_TOKEN"); token != "" {
+		c.Confluence.Token = token
+	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -159,6 +159,34 @@ func (s *ConfigSuite) TestReadConfigValidPreservesDefaultsForMissingFields() {
 	})
 }
 
+func (s *ConfigSuite) TestReadConfigWithEnv() {
+	s.T().Setenv("MCP_CONFLUENCE_URL", "https://env-confluence.example.com")
+	s.T().Setenv("MCP_CONFLUENCE_USERNAME", "env-user")
+	s.T().Setenv("MCP_CONFLUENCE_TOKEN", "env-token")
+
+	configToml := `
+	[confluence]
+	url = "https://toml-confluence.example.com"
+	username = "toml-user"
+	token = "toml-token"
+	`
+
+	config, err := ReadToml([]byte(configToml))
+	s.Require().NoError(err)
+	s.Require().NotNil(config)
+	s.Require().NotNil(config.Confluence)
+
+	s.Run("URL is from env", func() {
+		s.Equal("https://env-confluence.example.com", config.Confluence.URL)
+	})
+	s.Run("Username is from env", func() {
+		s.Equal("env-user", config.Confluence.Username)
+	})
+	s.Run("Token is from env", func() {
+		s.Equal("env-token", config.Confluence.Token)
+	})
+}
+
 func (s *ConfigSuite) writeConfig(content string) string {
 	s.T().Helper()
 	tempDir := s.T().TempDir()


### PR DESCRIPTION
…t using environment variables. The following variables are now supported:

- `MCP_CONFLUENCE_URL`
- `MCP_CONFLUENCE_USERNAME`
- `MCP_CONFLUENCE_TOKEN`

These environment variables take precedence over the values defined in the `config.toml` file, but can be overridden by command-line flags.

A new test case has been added to verify this behavior.