### PR TITLE
This commit resolves two separate configuration issues:

### DIFF
--- a/charts/kubernetes-mcp-server/values.yaml
+++ b/charts/kubernetes-mcp-server/values.yaml
@@ -96,10 +96,10 @@ config:
   # - core
   # - config
   # - helm
-  # denied_resources:
-  # - group: ""
-  #   version: "v1"
-  #   kind: "Secret"
+  denied_resources:
+  - group: ""
+    version: "v1"
+    kind: "Secret"
   confluence:
     # url: https://your-confluence-instance
     # username: user

--- a/pkg/mcp/modules.go
+++ b/pkg/mcp/modules.go
@@ -1,5 +1,7 @@
 package mcp
 
 import _ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/config"
+import _ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/confluence"
 import _ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/core"
 import _ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/helm"
+import _ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/prometheus"


### PR DESCRIPTION
1.  **Fix TOML syntax for `denied_resources` in Helm chart:** The `denied_resources` key in the `config.toml` was being generated with an invalid syntax due to a misconfiguration in the Helm chart's `values.yaml`. This change corrects the structure in `values.yaml` to be a list of maps, which the Helm `toJson` function correctly converts into a valid TOML array of tables.

2.  **Restore missing toolset registrations:** The application was failing to recognize the `confluence` and `prometheus` toolsets because they were missing from the registration file at `pkg/mcp/modules.go`. This change adds the necessary blank imports for these toolsets, ensuring they are correctly registered on startup.