### PR TITLE
docs: Update README with Confluence and Prometheus toolsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,14 @@ This allows for more advanced configuration options that are not available throu
 
 #### Confluence Toolset
 
-To enable the Confluence toolset, you need to provide the URL, username, and an API token for your Confluence instance in the configuration file.
+To enable the Confluence toolset, you need to provide the URL, username, and an API token for your Confluence instance.
+
+This can be done via environment variables:
+- `MCP_CONFLUENCE_URL`
+- `MCP_CONFLUENCE_USERNAME`
+- `MCP_CONFLUENCE_TOKEN`
+
+Or by adding the following to your configuration file:
 
 **Example `config.toml`:**
 ```toml
@@ -201,6 +208,16 @@ To enable the Confluence toolset, you need to provide the URL, username, and an 
 url = "https://your-confluence-domain.com"
 username = "your-username"
 token = "your-api-token"
+```
+
+#### Prometheus Toolset
+
+To enable the Prometheus toolset, you need to provide the URL for your Prometheus instance.
+
+**Example `config.toml`:**
+```toml
+[prometheus]
+url = "http://localhost:9090"
 ```
 
 #### Advanced Configuration
@@ -224,11 +241,13 @@ The following sets of tools are available (all on by default):
 
 <!-- AVAILABLE-TOOLSETS-START -->
 
-| Toolset | Description                                                                         |
-|---------|-------------------------------------------------------------------------------------|
-| config  | View and manage the current local Kubernetes configuration (kubeconfig)             |
-| core    | Most common tools for Kubernetes management (Pods, Generic Resources, Events, etc.) |
-| helm    | Tools for managing Helm charts and releases                                         |
+| Toolset    | Description                                                                         |
+|------------|-------------------------------------------------------------------------------------|
+| config     | View and manage the current local Kubernetes configuration (kubeconfig)             |
+| confluence | Tools for interacting with Confluence                                               |
+| core       | Most common tools for Kubernetes management (Pods, Generic Resources, Events, etc.) |
+| helm       | Tools for managing Helm charts and releases                                         |
+| prometheus | Tools for interacting with Prometheus                                               |
 
 <!-- AVAILABLE-TOOLSETS-END -->
 
@@ -242,6 +261,18 @@ The following sets of tools are available (all on by default):
 
 - **configuration_view** - Get the current Kubernetes configuration content as a kubeconfig YAML
   - `minified` (`boolean`) - Return a minified version of the configuration. If set to true, keeps only the current-context and the relevant pieces of the configuration for that context. If set to false, all contexts, clusters, auth-infos, and users are returned in the configuration. (Optional, default true)
+
+</details>
+
+<details>
+
+<summary>confluence</summary>
+
+- **confluence.createPage** - Create a new page in Confluence.
+  - `space_key` (`string`) **(required)** - The key of the space to create the page in.
+  - `title` (`string`) **(required)** - The title of the new page.
+  - `content` (`string`) **(required)** - The content of the new page in Confluence Storage Format (XHTML).
+  - `parent_id` (`string`) - Optional ID of a parent page.
 
 </details>
 
@@ -347,6 +378,15 @@ The following sets of tools are available (all on by default):
 - **helm_uninstall** - Uninstall a Helm release in the current or provided namespace
   - `name` (`string`) **(required)** - Name of the Helm release to uninstall
   - `namespace` (`string`) - Namespace to uninstall the Helm release from (Optional, current namespace if not provided)
+
+</details>
+
+<details>
+
+<summary>prometheus</summary>
+
+- **prometheus.runQuery** - Run a PromQL query.
+  - `query` (`string`) **(required)** - The PromQL query to run.
 
 </details>
 


### PR DESCRIPTION
Adds documentation for the Confluence and Prometheus toolsets, including configuration instructions and tool descriptions.