### PR TITLE
fix: Register disabled toolsets to prevent startup panic

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -36,22 +36,23 @@ type Configuration struct {
 func (c *Configuration) Toolsets() []api.Toolset {
 	if c.toolsets == nil {
 		for _, toolsetName := range c.StaticConfig.Toolsets {
-			var toolset api.Toolset
-			var err error
-			if toolsetName == "confluence" {
+			var (
+				toolset api.Toolset
+				err     error
+			)
+
+			switch toolsetName {
+			case "confluence":
 				toolset, err = confluence.NewToolset(c.Confluence)
-				if err != nil {
-					klog.Warningf("failed to initialize confluence toolset: %v", err)
-					continue
-				}
-			} else if toolsetName == "prometheus" {
+			case "prometheus":
 				toolset, err = prometheus.NewToolset(c.Prometheus)
-				if err != nil {
-					klog.Warningf("failed to initialize prometheus toolset: %v", err)
-					continue
-				}
-			} else {
+			default:
 				toolset = toolsets.ToolsetFromString(toolsetName)
+			}
+
+			if err != nil {
+				klog.Warningf("failed to initialize %s toolset: %v", toolsetName, err)
+				continue
 			}
 
 			if toolset != nil {

--- a/pkg/toolsets/confluence/toolset.go
+++ b/pkg/toolsets/confluence/toolset.go
@@ -13,6 +13,10 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 )
 
+func init() {
+	toolsets.Register(&disabledToolset{})
+}
+
 // NewToolset returns a new toolset for Confluence.
 func NewToolset(cfg *config.ConfluenceConfig) (api.Toolset, error) {
 	if cfg == nil || cfg.URL == "" {

--- a/pkg/toolsets/prometheus/toolset.go
+++ b/pkg/toolsets/prometheus/toolset.go
@@ -16,6 +16,10 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 )
 
+func init() {
+	toolsets.Register(&disabledToolset{})
+}
+
 // NewToolset returns a new toolset for Prometheus.
 func NewToolset(cfg *config.PrometheusConfig) (api.Toolset, error) {
 	if cfg == nil || cfg.URL == "" {


### PR DESCRIPTION
The application was panicking during startup because toolsets that require configuration (e.g., Confluence, Prometheus) were not being registered correctly. This led to a nil pointer dereference during startup validation when the application tried to access the unregistered toolsets.

This commit fixes the issue by registering a "disabled" version of the `confluence` and `prometheus` toolsets in an `init()` function. This ensures that the toolsets are always registered, allowing the startup validation to pass. The full toolset is then initialized later when the configuration is available.

Additionally, the toolset initialization logic in `pkg/mcp/mcp.go` has been refactored to use a `switch` statement for better readability and to handle errors more cleanly after the toolset creation attempt.