### PR TITLE
feat: Add health check handler for root endpoint

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -41,6 +41,17 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, staticConfig *config.Stat
 	mux.Handle(sseEndpoint, sseServer)
 	mux.Handle(sseMessageEndpoint, sseServer)
 	mux.Handle(mcpEndpoint, streamableHttpServer)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		// The health check now lives at /healthz, and should be used for any
+		// automated liveness/readiness probes.
+		// However, some health checkers may only hit the root, so we'll return
+		// an OK status here as well, to avoid unnecessary restarts.
+		w.WriteHeader(http.StatusOK)
+	})
 	mux.HandleFunc(healthEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -285,9 +285,29 @@ func TestHealthCheck(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to get health check endpoint: %v", err)
 			}
-			t.Cleanup(func() { _ = resp.Body.Close })
+			t.Cleanup(func() { _ = resp.Body.Close() })
 			if resp.StatusCode != http.StatusOK {
 				t.Errorf("Expected HTTP 200 OK, got %d", resp.StatusCode)
+			}
+		})
+		t.Run("Exposes health check endpoint at /", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("http://%s/", ctx.HttpAddress))
+			if err != nil {
+				t.Fatalf("Failed to get health check endpoint: %v", err)
+			}
+			t.Cleanup(func() { _ = resp.Body.Close() })
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("Expected HTTP 200 OK, got %d", resp.StatusCode)
+			}
+		})
+		t.Run("Returns 404 for unknown paths", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("http://%s/unknown", ctx.HttpAddress))
+			if err != nil {
+				t.Fatalf("Failed to get unknown endpoint: %v", err)
+			}
+			t.Cleanup(func() { _ = resp.Body.Close() })
+			if resp.StatusCode != http.StatusNotFound {
+				t.Errorf("Expected HTTP 404 Not Found, got %d", resp.StatusCode)
 			}
 		})
 	})


### PR DESCRIPTION
The server was shutting down due to failing health checks that were targeting the root path (`/`) and receiving a 404 Not Found error.

This change adds a new handler for the root path that returns a 200 OK status, ensuring that health probes pass regardless of whether they target `/` or the existing `/healthz` endpoint.

A check is included to ensure that only the exact `/` path is handled, while other unmatched paths continue to return a 404 error.

Unit tests have been added to verify the new functionality, and a minor bug in an existing test was also corrected.